### PR TITLE
If "npm audit" exits as 0 there are no vulnerabilities so we should exit 0

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,9 +85,7 @@ if( typeof registry !== 'undefined' ) {
 exec(command, (err, stdout, stderr) => {
   let exitCode = 0;
   if (err === null) {
-    console.log('An unexpected error has occurred')
-    console.log(stderr);
-    exitCode = 255;
+    console.log('No vulnerabilities found.')
   } else {
     let data = JSON.parse(stdout);
     let advisories = Object.entries(data.advisories);


### PR DESCRIPTION
Seems simple enough but I have not really worked with node before. I did not explicitly set exitCode as it has a default of 0.