### PR TITLE
Fixed max buffer for stdout

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ if( typeof registry !== 'undefined' ) {
 
 //
 // Execute and capture the output for processing
-exec(command, (err, stdout, stderr) => {
+exec(command, {maxBuffer: 500 * 1024}, (err, stdout, stderr) => {
   let exitCode = 0;
   if (err === null) {
     console.log('No vulnerabilities found.')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-audit-ci-wrapper",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "A wrapper for 'npm audit' which can be configurable for use in a CI/CD tool like Jenkins",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This change increases the maximum stdout buffer storage from 200kb to 500kb for cases when the npm audit json exceeds 200kb. It avoids `unexpected end of JSON` errors being thrown from JSON.parse.