### PR TITLE
convert filtered advisories to objects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,5 @@ addons:
     token: "${SONAR_TOKEN}"
 script:
   - npm run test
-  - sonar-scanner
+  - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then sonar-scanner; fi # sonar only on non-PRs
   - npm run stryker

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -39,7 +39,10 @@ function parse_audit_results(err, stdout, threshold, ignoreDev, json_output = fa
     if (json_output) {
       var retVal = data;
       retVal.advisories = {};
-      retVal.advisories = flaggedDepenencies;
+      // convert filtered advisories to objects (instead of arrays) to match output of npm audit --json
+      flaggedDepenencies.forEach((advisory) => {
+        Object.assign(retVal.advisories, { [advisory[0]]: advisory[1] });
+      });
       cli_output = JSON.stringify(retVal) + '\n';
     } else { // If any vulnerabilities exceed the threshold and are not filtered, print the details and fail the build.
       if (flaggedDepenencies.length > 0) {

--- a/lib/parser.test.js
+++ b/lib/parser.test.js
@@ -66,6 +66,10 @@ test('Validate run with 7 vulnerabilities and JSON output', () => {
   expect(cli_output).toContain('"module_name"');
   expect(cli_output.substring((cli_output.length - 1), cli_output.length)).toBe('\n');
   expect(exitCode).toBe(0);
+  // since we are not filtering, we should have the same advisories in the output as the input
+  const cli_output_json = JSON.parse(cli_output);
+  const data = JSON.parse(test_data);
+  expect(cli_output_json.advisories.keys).toEqual(data.advisories.keys);
 });
 
 /*


### PR DESCRIPTION
# Resolves #32 

# Description
When outputting JSON, ensure the advisories object matches the data type found in the output of `npm audit --json`. Array filter returns an array so I converted the results to an object.
@InfoSec812 