### PR TITLE
improvement: report output readability

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -53,9 +53,9 @@ function parse_audit_results(err, stdout, threshold, ignoreDev, json_output = fa
       // If any vulnerabilities exceed the threshold and are not filtered, print the details and fail the build.
 
       cli_output += ignoreDev ? (
-        "The following production dependencies "
+        "The following production vulnerabilities "
       ) : (
-        "The following dependencies "
+        "The following vulnerabilities "
       )
 
       cli_output += "are " + validThresholds[threshold] + " severity or higher:\n"

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -50,6 +50,8 @@ function parse_audit_results(err, stdout, threshold, ignoreDev, json_output = fa
       retVal.advisories = flaggedDepenencies;
       cli_output = JSON.stringify(retVal, null, 2) + '\n';
     } else if (flaggedDepenencies.length > 0) {
+      // If any vulnerabilities exceed the threshold and are not filtered, print the details and fail the build.
+
       cli_output += ignoreDev ? (
         "The following production dependencies "
       ) : (

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -50,7 +50,6 @@ function parse_audit_results(err, stdout, threshold, ignoreDev, json_output = fa
       retVal.advisories = flaggedDepenencies;
       cli_output = JSON.stringify(retVal, null, 2) + '\n';
     } else if (flaggedDepenencies.length > 0) {
-      // cli_output += 'There are vulnerable dependencies which exceed the selected threshold and scope:\n\n';
       cli_output += ignoreDev ? (
         "The following production dependencies "
       ) : (

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -15,6 +15,7 @@
  */
 
 const util = require('util');
+const Table = require("cli-table")
 const { validThresholds } = require('./parse_args');
 
 /**
@@ -48,26 +49,38 @@ function parse_audit_results(err, stdout, threshold, ignoreDev, json_output = fa
       retVal.advisories = {};
       retVal.advisories = flaggedDepenencies;
       cli_output = JSON.stringify(retVal, null, 2) + '\n';
-    } else { // If any vulnerabilities exceed the threshold and are not filtered, print the details and fail the build.
-      if (flaggedDepenencies.length > 0) {
-        cli_output += 'There are vulnerable dependencies which exceed the selected threshold and scope:\n';
-        exitCode = 1;
-      }
+    } else if (flaggedDepenencies.length > 0) {
+      // cli_output += 'There are vulnerable dependencies which exceed the selected threshold and scope:\n\n';
+      cli_output += ignoreDev ? (
+        "The following production dependencies "
+      ) : (
+        "The following dependencies "
+      )
+
+      cli_output += "are " + validThresholds[threshold] + " severity or higher:\n"
+
+      exitCode = 1;
+
+      const flagTable = new Table({
+        head: ["module", "severity", "overview"]
+      })
+
       flaggedDepenencies.forEach((advisory) => {                      // Print out dependencies which exceed the threshold
         let libraryName = advisory[1].module_name;
         let libraryVersion = advisory[1].findings[0].version;
         let advisoryOverview = 'https://www.npmjs.com/advisories/' + advisory[0];
         let severity = advisory[1].severity;
-        cli_output += util.format(
-                                    "    %s(%s): %s (%s >= %s)\n",
-                                    libraryName.padStart(30),
-                                    libraryVersion.padEnd(20),
-                                    advisoryOverview.padEnd(50),
-                                    severity,
-                                    validThresholds[threshold]);
+        flagTable.push([
+          libraryName + "@" + libraryVersion,
+          severity,
+          advisoryOverview
+        ])
       });
+
+      cli_output += flagTable.toString() + "\n"
     }
   }
+
   return { exitCode, cli_output };
 }
 

--- a/lib/parser.test.js
+++ b/lib/parser.test.js
@@ -94,7 +94,7 @@ test('Validate run with 7 vulnerabilities', () => {
   expect(cli_output).not.toContain('{');
   expect(cli_output).toContain("growl");
   expect(cli_output).toContain('https://www.npmjs.com/advisories/');
-  expect(cli_output).toContain('The following dependencies are low severity or higher:');
+  expect(cli_output).toContain('The following vulnerabilities are low severity or higher:');
   expect(exitCode).toBe(1);
 });
 
@@ -108,7 +108,7 @@ test('Validate run with 7 vulnerabilities, a high severity cutoff, and productio
   expect(cli_output).not.toContain('{');
   expect(cli_output).toContain("https-proxy-agent@1.0.0");
   expect(cli_output).toContain('https://www.npmjs.com/advisories/');
-  expect(cli_output).toContain('The following production dependencies are high severity or higher:');
+  expect(cli_output).toContain('The following production vulnerabilities are high severity or higher:');
   expect(exitCode).toBe(1);
 });
 

--- a/lib/parser.test.js
+++ b/lib/parser.test.js
@@ -85,7 +85,8 @@ test('Validate run with 0 vulnerabilities', () => {
 });
 
 /*
- * If 7 vulnerabilities exceed the threshold and dev dependencies are not ignore, expect a non-zero exit code
+ * If 7 vulnerabilities exceed the threshold and dev dependencies are not
+ * ignore, expect a non-zero exit code and correct messaging
  */
 test('Validate run with 7 vulnerabilities', () => {
   const test_data = readFileSync('test_data/vue_js_app.json', 'utf8');
@@ -93,7 +94,21 @@ test('Validate run with 7 vulnerabilities', () => {
   expect(cli_output).not.toContain('{');
   expect(cli_output).toContain("growl");
   expect(cli_output).toContain('https://www.npmjs.com/advisories/');
-  expect(cli_output).toContain('There are vulnerable dependencies which exceed the selected threshold and scope:');
+  expect(cli_output).toContain('The following dependencies are low severity or higher:');
+  expect(exitCode).toBe(1);
+});
+
+/*
+ * If 7 vulnerabilities exceed the high threshold and dev dependencies are
+ * ignored, expect a non-zero exit code and correct messaging.
+ */
+test('Validate run with 7 vulnerabilities, a high severity cutoff, and production-only', () => {
+  const test_data = readFileSync('test_data/vue_js_app.json', 'utf8');
+  let { exitCode, cli_output } = parse_audit_results("", test_data, HIGH_THRESHOLD, true);
+  expect(cli_output).not.toContain('{');
+  expect(cli_output).toContain("https-proxy-agent@1.0.0");
+  expect(cli_output).toContain('https://www.npmjs.com/advisories/');
+  expect(cli_output).toContain('The following production dependencies are high severity or higher:');
   expect(exitCode).toBe(1);
 });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-audit-ci-wrapper",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "A wrapper for 'npm audit' which can be configurable for use in a CI/CD tool like Jenkins",
   "keywords": [
     "npm",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "argv": "0.0.2"
+    "argv": "0.0.2",
+    "cli-table": "^0.3.1"
   },
   "bin": {
     "npm-audit-ci-wrapper": "./bin/index.js"


### PR DESCRIPTION
**This PR introduces a table report format, and makes the report messaging more helpful by repeating back the selected options to the user.**

### Context

I'm integrating `npm-audit-ci-wrapper` in [Swagger UI](http://github.com/swagger-api/swagger-ui/). 

This is the only module with the right combination of options for our purposes, but I found that vulnerability readouts were overflowing my (relatively-narrow) terminal window, and the static message coming back from the utility wasn't helpful in differentiating between the two runs we want to do for our audits.

### Before

![image](https://user-images.githubusercontent.com/680248/61094431-c56bfa80-a414-11e9-8733-9abf8e26ee09.png)


### After

![image](https://user-images.githubusercontent.com/680248/61096531-8aba9000-a41d-11e9-818c-5d20f1a5f86b.png)

