### PR TITLE
Issue 57: Handle npm web service timeout gracefully

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -30,6 +30,7 @@ function parse_audit_results(err, data, threshold, ignoreDev, jsonOutput = false
   let exitCode = 0;
   let cliOutput = "";
   if (data.hasOwnProperty('error')) {
+    // When there is an error communicating with the NPM registry audit service, short-circuit and tell the user the error.
     cliOutput = `${data['error']['code']}: ${data['error']['summary']}`;
     exitCode = 12;
     return { exitCode, cliOutput };

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -29,6 +29,11 @@ const { validThresholds } = require('./parse_args');
 function parse_audit_results(err, data, threshold, ignoreDev, jsonOutput = false, whitelist = []) {
   let exitCode = 0;
   let cliOutput = "";
+  if (data.hasOwnProperty('error')) {
+    cliOutput = `${data['error']['code']}: ${data['error']['summary']}`;
+    exitCode = 12;
+    return { exitCode, cliOutput };
+  }
   if (err === null) {
     if (jsonOutput) {
       data['advisories'] = {};

--- a/lib/parser.test.js
+++ b/lib/parser.test.js
@@ -278,3 +278,15 @@ test('Ensure that large JSON responses from NPM audit are handled properly', don
       done();
     }));
 });
+
+test('Ensure that errors communicating with the registry service are properly handled', done => {
+  createReadStream('test_data/registry_error.json', 'utf8')
+    .pipe(JSONStream.parse())
+    .pipe(es.mapSync(function(data) {
+      const { exitCode, cliOutput } = parse_audit_results(null, data, CRIT_THRESHOLD, true);
+      console.log(cliOutput);
+      expect(cliOutput.length).toBeGreaterThan(0);
+      expect(cliOutput).toContain("ENOTFOUND");
+      done();
+    }));
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-audit-ci-wrapper",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "A wrapper for 'npm audit' which can be configurable for use in a CI/CD tool like Jenkins",
   "keywords": [
     "npm",

--- a/test_data/registry_error.json
+++ b/test_data/registry_error.json
@@ -1,0 +1,7 @@
+{
+  "error": {
+    "code": "ENOTFOUND",
+    "summary": "request to https://broken.npmjs.org/-/npm/v1/security/audits failed, reason: getaddrinfo ENOTFOUND broken.npmjs.org",
+    "detail": "This is a problem related to network connectivity.\nIn most cases you are behind a proxy or have bad network settings.\n\nIf you are behind a proxy, please make sure that the\n'proxy' config is set properly.  See: 'npm help config'"
+  }
+}


### PR DESCRIPTION
# Resolves #57

# Description
Added logic and unit test to ensure that communication problems with the NPM registry are properly 
handled so that it is obvious when there is a problem with the upstream server versus this application