### PR TITLE
Issue 67 Simplifying package.json reading in tests

### DIFF
--- a/bin/index.test.js
+++ b/bin/index.test.js
@@ -16,10 +16,9 @@
 const { readFileSync } = require('fs');
 
 test('Verify that version from package.json matches version in the code', () => {
-  const packageJson = readFileSync('package.json', 'utf8');
-  const packageVersion = JSON.parse(packageJson).version;
   const testRegEx = new RegExp(`VERSION = '([0-9.]+)'`);
   const indexJs = readFileSync('bin/index.js', 'utf8');
   const indexJsVersion = indexJs.match(testRegEx);
-  expect(indexJsVersion[0]).toBe(`VERSION = '${packageVersion}'`);
+  const packageJsonVersion = require('../package.json').version;
+  expect(indexJsVersion[0]).toBe(`VERSION = '${packageJsonVersion}'`);
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-audit-ci-wrapper",
-  "version": "2.5.5",
+  "version": "2.6.5",
   "description": "A wrapper for 'npm audit' which can be configurable for use in a CI/CD tool like Jenkins",
   "keywords": [
     "npm",


### PR DESCRIPTION
# Resolves #67 

# Description
We can use `require` directly without bother with `fs.readFileSync` and `JSON.parse`.