### PR TITLE
Issue 72:  npm version update breaking dev dependency filter

### DIFF
--- a/lib/parse_args.js
+++ b/lib/parse_args.js
@@ -78,7 +78,7 @@ const options = [
  */
 async function check_npm_version() {
   const { stdout } = await exec('npm --version');
-  const [major] = stdout.trim().split(".")[0];
+  const [major, minor, patch] = stdout.trim().split(".");
   const majorInt = parseInt(major);
   return (majorInt >= 6);
 }

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -51,7 +51,12 @@ function parse_audit_results(err, data, threshold, ignoreDev, jsonOutput = false
   } else {
     const advisories = Object.entries(data.advisories);
 
-    const flaggedDependencies = filter_advisories(advisories, ignoreDev, threshold, whitelist);
+    let moduleInfo = {};
+    if (data.hasOwnProperty('actions')) {
+      moduleInfo = process_actions(data.actions);
+    }
+
+    const flaggedDependencies = filter_advisories(advisories, ignoreDev, threshold, moduleInfo, whitelist);
 
     // If `-j` or `--json` passed, return the json data with the appropriate filters applied
     if (jsonOutput) {
@@ -103,19 +108,21 @@ function parse_audit_results(err, data, threshold, ignoreDev, jsonOutput = false
  * @param {Object[]} advisories An array of Advisory objects returned from NPM Audit
  * @param {boolean} ignoreDev Should dev dependencies be ignored?
  * @param {number} threshold The severity threshold above which a vulnerability will not be ignored
+ * @param {Object} moduleInfo A Key/Value Map of module name to dev/prod status
  * @param {string[]} whitelist A (possibly empty) list of modules/versions which should be ignored
  * @returns An array (possibly empty) of advisory objects
  */
-function filter_advisories(advisories, ignoreDev, threshold, whitelist = []) {
-  const filteredByThreshold = advisories.filter((advisory, idx) => {
-    return (!(advisory[1].findings[0].dev && ignoreDev));   // Filter out Dev dependencies when indicated
+function filter_advisories(advisories, ignoreDev, threshold, moduleInfo = {}, whitelist = []) {
+  const filteredByDev = advisories.filter((advisory, idx) => {
+    const isDev = advisory[1].findings[0].dev || moduleInfo[advisory[1].module_name];
+    return (!(isDev && ignoreDev));   // Filter out Dev dependencies when indicated
   });
 
-  const filteredByDev = filteredByThreshold.filter((advisory, idx) => {
+  const filteredByThreshold = filteredByDev.filter((advisory, idx) => {
     return (validThresholds.indexOf(advisory[1].severity) >= threshold);  // Filter out lower severities when indicated
   });
 
-  return filteredByDev.filter((advisory, idx) => {
+  return filteredByThreshold.filter((advisory, idx) => {
     const moduleName = advisory[1].module_name;
     const moduleVersion = advisory[1].findings[0].version;
     for (let i = 0; i < whitelist.length; i++) {
@@ -132,7 +139,22 @@ function filter_advisories(advisories, ignoreDev, threshold, whitelist = []) {
   });
 }
 
+/**
+ * Parse the "Actions" section of the NPM Audit report and determine which modules are dev dependencies and which are not
+ * @param {Object[]} actions An array/list of Action objects from NPM Audit
+ */
+function process_actions(actions) {
+  let moduleInfo = {};
+  actions.forEach(action => {
+    const module_name = action.module;
+    const is_dev_dependency = action.resolves.filter(path => path.dev).length > 0;
+    moduleInfo[module_name] = is_dev_dependency;
+  });
+  return moduleInfo;
+}
+
 module.exports = {
   parse_audit_results,
-  filter_advisories: filter_advisories
+  filter_advisories: filter_advisories,
+  process_actions
 };

--- a/lib/parser.test.js
+++ b/lib/parser.test.js
@@ -17,7 +17,7 @@
 const JSONStream = require('JSONStream');
 const es = require('event-stream');
 const { readFileSync, createReadStream } = require('fs');
-const { parse_audit_results, filter_advisories } = require('./parser');
+const { parse_audit_results, filter_advisories, process_actions } = require('./parser');
 
 const LOW_THRESHOLD = 0;
 const MOD_THRESHOLD = 1;
@@ -215,7 +215,7 @@ test('Validate whitelisting of https-proxy-agent:1.0.0', () => {
   const test_data = readFileSync('test_data/vue_js_app.json', 'utf8');
   const data = JSON.parse(test_data);
   const results = filter_advisories(Object.entries(data.advisories), true, HIGH_THRESHOLD, ['https-proxy-agent:1.0.0']);
-  expect(results.length).toBe(0);
+  expect(results.length).toBe(1);
 });
 
 /*
@@ -225,7 +225,7 @@ test('Validate whitelisting of all versions of https-proxy-agent', () => {
   const test_data = readFileSync('test_data/vue_js_app.json', 'utf8');
   const data = JSON.parse(test_data);
   const results = filter_advisories(Object.entries(data.advisories), true, HIGH_THRESHOLD, ['https-proxy-agent']);
-  expect(results.length).toBe(0);
+  expect(results.length).toBe(1);
 });
 
 /*
@@ -235,7 +235,7 @@ test('Validate whitelisting of all versions of https-proxy-agent using wildcard'
   const test_data = readFileSync('test_data/vue_js_app.json', 'utf8');
   const data = JSON.parse(test_data);
   const results = filter_advisories(Object.entries(data.advisories), true, HIGH_THRESHOLD, ['https-proxy-agent:*']);
-  expect(results.length).toBe(0);
+  expect(results.length).toBe(1);
 });
 
 /*
@@ -276,6 +276,22 @@ test('Ensure that large JSON responses from NPM audit are handled properly', don
       expect(cliOutput.length).toBeGreaterThan(0);
       done();
     }));
+});
+
+test('Ensure that process_actions can extract module dev/prod status', () => {
+  const test_data = readFileSync('test_data/stoplight-cryptiles.json', 'utf8');
+  const data = JSON.parse(test_data);
+  const moduleInfo = process_actions(data.actions);
+  expect(moduleInfo['hoek']).toBeDefined();
+  expect(moduleInfo['hoek']).toEqual(true);
+});
+
+test('Ensure that dev dependencies do not cause problems when disabled', () => {
+  const test_data = readFileSync('test_data/stoplight-cryptiles.json', 'utf8');
+  const data = JSON.parse(test_data);
+  const moduleInfo = process_actions(data.actions);
+  const results = filter_advisories(Object.entries(data.advisories), true, HIGH_THRESHOLD, moduleInfo);
+  expect(results.length).toBe(0);
 });
 
 test('Ensure that errors communicating with the registry service are properly handled', done => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-audit-ci-wrapper",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "A wrapper for 'npm audit' which can be configurable for use in a CI/CD tool like Jenkins",
   "keywords": [
     "npm",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-audit-ci-wrapper",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "description": "A wrapper for 'npm audit' which can be configurable for use in a CI/CD tool like Jenkins",
   "keywords": [
     "npm",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-audit-ci-wrapper",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "A wrapper for 'npm audit' which can be configurable for use in a CI/CD tool like Jenkins",
   "keywords": [
     "npm",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-audit-ci-wrapper",
-  "version": "3.2.0",
+  "version": "3.0.0",
   "description": "A wrapper for 'npm audit' which can be configurable for use in a CI/CD tool like Jenkins",
   "keywords": [
     "npm",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-audit-ci-wrapper",
-  "version": "2.6.6",
+  "version": "3.0.0",
   "description": "A wrapper for 'npm audit' which can be configurable for use in a CI/CD tool like Jenkins",
   "keywords": [
     "npm",

--- a/test_data/stoplight-cryptiles.json
+++ b/test_data/stoplight-cryptiles.json
@@ -1,0 +1,626 @@
+{
+  "actions": [
+    {
+      "isMajor": true,
+      "action": "install",
+      "resolves": [
+        {
+          "id": 664,
+          "path": "@stoplight/prism-cli>@stoplight/prism-http>@stoplight/http-spec>json-schema-generator>request>stringstream",
+          "dev": true,
+          "optional": false,
+          "bundled": false
+        },
+        {
+          "id": 664,
+          "path": "@stoplight/prism-cli>@stoplight/prism-http-server>@stoplight/prism-http>@stoplight/http-spec>json-schema-generator>request>stringstream",
+          "dev": true,
+          "optional": false,
+          "bundled": false
+        },
+        {
+          "id": 996,
+          "path": "@stoplight/prism-cli>@stoplight/prism-http>@stoplight/http-spec>json-schema-generator>request>extend",
+          "dev": true,
+          "optional": false,
+          "bundled": false
+        },
+        {
+          "id": 996,
+          "path": "@stoplight/prism-cli>@stoplight/prism-http-server>@stoplight/prism-http>@stoplight/http-spec>json-schema-generator>request>extend",
+          "dev": true,
+          "optional": false,
+          "bundled": false
+        },
+        {
+          "id": 1179,
+          "path": "@stoplight/prism-cli>@stoplight/prism-http>@stoplight/http-spec>json-schema-generator>optimist>minimist",
+          "dev": true,
+          "optional": false,
+          "bundled": false
+        },
+        {
+          "id": 1179,
+          "path": "@stoplight/prism-cli>@stoplight/prism-http-server>@stoplight/prism-http>@stoplight/http-spec>json-schema-generator>optimist>minimist",
+          "dev": true,
+          "optional": false,
+          "bundled": false
+        },
+        {
+          "id": 1523,
+          "path": "@stoplight/prism-cli>@stoplight/prism-core>lodash",
+          "dev": true,
+          "optional": false,
+          "bundled": false
+        },
+        {
+          "id": 1523,
+          "path": "@stoplight/prism-cli>@stoplight/prism-http>@stoplight/prism-core>lodash",
+          "dev": true,
+          "optional": false,
+          "bundled": false
+        },
+        {
+          "id": 1523,
+          "path": "@stoplight/prism-cli>@stoplight/prism-http-server>@stoplight/prism-http>@stoplight/prism-core>lodash",
+          "dev": true,
+          "optional": false,
+          "bundled": false
+        },
+        {
+          "id": 1523,
+          "path": "@stoplight/prism-cli>@stoplight/prism-http-server>@stoplight/prism-core>lodash",
+          "dev": true,
+          "optional": false,
+          "bundled": false
+        },
+        {
+          "id": 1523,
+          "path": "@stoplight/prism-cli>@stoplight/prism-http>lodash",
+          "dev": true,
+          "optional": false,
+          "bundled": false
+        },
+        {
+          "id": 1523,
+          "path": "@stoplight/prism-cli>@stoplight/prism-http-server>@stoplight/prism-http>lodash",
+          "dev": true,
+          "optional": false,
+          "bundled": false
+        },
+        {
+          "id": 1523,
+          "path": "@stoplight/prism-cli>@stoplight/prism-http-server>lodash",
+          "dev": true,
+          "optional": false,
+          "bundled": false
+        },
+        {
+          "id": 1523,
+          "path": "@stoplight/prism-cli>lodash",
+          "dev": true,
+          "optional": false,
+          "bundled": false
+        }
+      ],
+      "module": "@stoplight/prism-cli",
+      "target": "4.0.0"
+    },
+    {
+      "action": "update",
+      "resolves": [
+        {
+          "id": 606,
+          "path": "@stoplight/prism-cli>@stoplight/prism-http>@stoplight/http-spec>json-schema-generator>request>http-signature>sshpk",
+          "dev": true,
+          "optional": false,
+          "bundled": false
+        },
+        {
+          "id": 606,
+          "path": "@stoplight/prism-cli>@stoplight/prism-http-server>@stoplight/prism-http>@stoplight/http-spec>json-schema-generator>request>http-signature>sshpk",
+          "dev": true,
+          "optional": false,
+          "bundled": false
+        }
+      ],
+      "module": "sshpk",
+      "target": "1.16.1",
+      "depth": 8
+    },
+    {
+      "action": "update",
+      "resolves": [
+        {
+          "id": 1179,
+          "path": "@stoplight/prism-cli>@stoplight/prism-http>@stoplight/http-spec>json-schema-generator>mkdirp>minimist",
+          "dev": true,
+          "optional": false,
+          "bundled": false
+        },
+        {
+          "id": 1179,
+          "path": "@stoplight/prism-cli>@stoplight/prism-http-server>@stoplight/prism-http>@stoplight/http-spec>json-schema-generator>mkdirp>minimist",
+          "dev": true,
+          "optional": false,
+          "bundled": false
+        }
+      ],
+      "module": "mkdirp",
+      "target": "0.5.5",
+      "depth": 6
+    },
+    {
+      "action": "review",
+      "module": "hoek",
+      "resolves": [
+        {
+          "id": 566,
+          "path": "@stoplight/prism-cli>@stoplight/prism-http>@stoplight/http-spec>json-schema-generator>request>hawk>boom>hoek",
+          "dev": true,
+          "bundled": false,
+          "optional": false
+        },
+        {
+          "id": 566,
+          "path": "@stoplight/prism-cli>@stoplight/prism-http-server>@stoplight/prism-http>@stoplight/http-spec>json-schema-generator>request>hawk>boom>hoek",
+          "dev": true,
+          "bundled": false,
+          "optional": false
+        },
+        {
+          "id": 566,
+          "path": "@stoplight/prism-cli>@stoplight/prism-http>@stoplight/http-spec>json-schema-generator>request>hawk>cryptiles>boom>hoek",
+          "dev": true,
+          "bundled": false,
+          "optional": false
+        },
+        {
+          "id": 566,
+          "path": "@stoplight/prism-cli>@stoplight/prism-http-server>@stoplight/prism-http>@stoplight/http-spec>json-schema-generator>request>hawk>cryptiles>boom>hoek",
+          "dev": true,
+          "bundled": false,
+          "optional": false
+        },
+        {
+          "id": 566,
+          "path": "@stoplight/prism-cli>@stoplight/prism-http>@stoplight/http-spec>json-schema-generator>request>hawk>hoek",
+          "dev": true,
+          "bundled": false,
+          "optional": false
+        },
+        {
+          "id": 566,
+          "path": "@stoplight/prism-cli>@stoplight/prism-http-server>@stoplight/prism-http>@stoplight/http-spec>json-schema-generator>request>hawk>hoek",
+          "dev": true,
+          "bundled": false,
+          "optional": false
+        },
+        {
+          "id": 566,
+          "path": "@stoplight/prism-cli>@stoplight/prism-http>@stoplight/http-spec>json-schema-generator>request>hawk>sntp>hoek",
+          "dev": true,
+          "bundled": false,
+          "optional": false
+        },
+        {
+          "id": 566,
+          "path": "@stoplight/prism-cli>@stoplight/prism-http-server>@stoplight/prism-http>@stoplight/http-spec>json-schema-generator>request>hawk>sntp>hoek",
+          "dev": true,
+          "bundled": false,
+          "optional": false
+        }
+      ]
+    },
+    {
+      "action": "review",
+      "module": "cryptiles",
+      "resolves": [
+        {
+          "id": 720,
+          "path": "@stoplight/prism-cli>@stoplight/prism-http>@stoplight/http-spec>json-schema-generator>request>hawk>cryptiles",
+          "dev": true,
+          "bundled": false,
+          "optional": false
+        },
+        {
+          "id": 720,
+          "path": "@stoplight/prism-cli>@stoplight/prism-http-server>@stoplight/prism-http>@stoplight/http-spec>json-schema-generator>request>hawk>cryptiles",
+          "dev": true,
+          "bundled": false,
+          "optional": false
+        },
+        {
+          "id": 1464,
+          "path": "@stoplight/prism-cli>@stoplight/prism-http>@stoplight/http-spec>json-schema-generator>request>hawk>cryptiles",
+          "dev": true,
+          "bundled": false,
+          "optional": false
+        },
+        {
+          "id": 1464,
+          "path": "@stoplight/prism-cli>@stoplight/prism-http-server>@stoplight/prism-http>@stoplight/http-spec>json-schema-generator>request>hawk>cryptiles",
+          "dev": true,
+          "bundled": false,
+          "optional": false
+        }
+      ]
+    }
+  ],
+  "advisories": {
+    "566": {
+      "findings": [
+        {
+          "version": "4.2.0",
+          "paths": [
+            "@stoplight/prism-cli>@stoplight/prism-http>@stoplight/http-spec>json-schema-generator>request>hawk>boom>hoek",
+            "@stoplight/prism-cli>@stoplight/prism-http-server>@stoplight/prism-http>@stoplight/http-spec>json-schema-generator>request>hawk>boom>hoek",
+            "@stoplight/prism-cli>@stoplight/prism-http>@stoplight/http-spec>json-schema-generator>request>hawk>cryptiles>boom>hoek",
+            "@stoplight/prism-cli>@stoplight/prism-http-server>@stoplight/prism-http>@stoplight/http-spec>json-schema-generator>request>hawk>cryptiles>boom>hoek",
+            "@stoplight/prism-cli>@stoplight/prism-http>@stoplight/http-spec>json-schema-generator>request>hawk>hoek",
+            "@stoplight/prism-cli>@stoplight/prism-http-server>@stoplight/prism-http>@stoplight/http-spec>json-schema-generator>request>hawk>hoek",
+            "@stoplight/prism-cli>@stoplight/prism-http>@stoplight/http-spec>json-schema-generator>request>hawk>sntp>hoek",
+            "@stoplight/prism-cli>@stoplight/prism-http-server>@stoplight/prism-http>@stoplight/http-spec>json-schema-generator>request>hawk>sntp>hoek"
+          ]
+        }
+      ],
+      "id": 566,
+      "created": "2018-04-20T21:25:58.421Z",
+      "updated": "2019-06-19T20:16:59.758Z",
+      "deleted": null,
+      "title": "Prototype Pollution",
+      "found_by": {
+        "name": "HoLyVieR"
+      },
+      "reported_by": {
+        "name": "HoLyVieR"
+      },
+      "module_name": "hoek",
+      "cves": [
+        "CVE-2018-3728"
+      ],
+      "vulnerable_versions": "<= 4.2.0 || >= 5.0.0 < 5.0.3",
+      "patched_versions": "> 4.2.0 < 5.0.0 || >= 5.0.3",
+      "overview": "Versions of `hoek` prior to 4.2.1 and 5.0.3 are vulnerable to prototype pollution.\n\nThe `merge` function, and the `applyToDefaults` and `applyToDefaultsWithShallow` functions which leverage `merge` behind the scenes, are vulnerable to a prototype pollution attack when provided an _unvalidated_ payload created from a JSON string containing the `__proto__` property.\n\nThis can be demonstrated like so:\n\n```javascript\nvar Hoek = require('hoek');\nvar malicious_payload = '{\"__proto__\":{\"oops\":\"It works !\"}}';\n\nvar a = {};\nconsole.log(\"Before : \" + a.oops);\nHoek.merge({}, JSON.parse(malicious_payload));\nconsole.log(\"After : \" + a.oops);\n```\n\nThis type of attack can be used to overwrite existing properties causing a potential denial of service.",
+      "recommendation": "Update to version 4.2.1, 5.0.3 or later.",
+      "references": "- [HackerOne Report](https://hackerone.com/reports/310439)",
+      "access": "public",
+      "severity": "moderate",
+      "cwe": "CWE-471",
+      "metadata": {
+        "module_type": "",
+        "exploitability": 5,
+        "affected_components": ""
+      },
+      "url": "https://npmjs.com/advisories/566"
+    },
+    "606": {
+      "findings": [
+        {
+          "version": "1.13.1",
+          "paths": [
+            "@stoplight/prism-cli>@stoplight/prism-http>@stoplight/http-spec>json-schema-generator>request>http-signature>sshpk",
+            "@stoplight/prism-cli>@stoplight/prism-http-server>@stoplight/prism-http>@stoplight/http-spec>json-schema-generator>request>http-signature>sshpk"
+          ]
+        }
+      ],
+      "id": 606,
+      "created": "2018-04-24T22:25:08.333Z",
+      "updated": "2018-09-07T17:39:16.549Z",
+      "deleted": null,
+      "title": "Regular Expression Denial of Service",
+      "found_by": {
+        "name": "Сковорода Никита Андреевич"
+      },
+      "reported_by": {
+        "name": "Сковорода Никита Андреевич"
+      },
+      "module_name": "sshpk",
+      "cves": [
+        "CVE-2018-3737"
+      ],
+      "vulnerable_versions": "<1.13.2 || >=1.14.0 <1.14.1",
+      "patched_versions": ">=1.13.2 < 1.14.0 || >=1.14.1",
+      "overview": "Versions of `sshpk` before 1.13.2 or 1.14.1 are vulnerable to regular expression denial of service when parsing crafted invalid public keys.",
+      "recommendation": "Update to version 1.13.2, 1.14.1 or later.",
+      "references": "- https://github.com/joyent/node-sshpk/blob/v1.13.1/lib/formats/ssh.js#L17\n- [HackerOne Report](https://hackerone.com/reports/319593)\n- https://github.com/joyent/node-sshpk/commit/46065d38a5e6d1bccf86d3efb2fb83c14e3f9957",
+      "access": "public",
+      "severity": "high",
+      "cwe": "CWE-400",
+      "metadata": {
+        "module_type": "",
+        "exploitability": 5,
+        "affected_components": ""
+      },
+      "url": "https://npmjs.com/advisories/606"
+    },
+    "664": {
+      "findings": [
+        {
+          "version": "0.0.5",
+          "paths": [
+            "@stoplight/prism-cli>@stoplight/prism-http>@stoplight/http-spec>json-schema-generator>request>stringstream",
+            "@stoplight/prism-cli>@stoplight/prism-http-server>@stoplight/prism-http>@stoplight/http-spec>json-schema-generator>request>stringstream"
+          ]
+        }
+      ],
+      "id": 664,
+      "created": "2018-05-16T19:39:37.463Z",
+      "updated": "2018-05-22T15:03:12.999Z",
+      "deleted": null,
+      "title": "Out-of-bounds Read",
+      "found_by": {
+        "name": "Сковорода Никита Андреевич"
+      },
+      "reported_by": {
+        "name": "Сковорода Никита Андреевич"
+      },
+      "module_name": "stringstream",
+      "cves": [],
+      "vulnerable_versions": "<=0.0.5",
+      "patched_versions": ">=0.0.6",
+      "overview": "All versions of `stringstream` are vulnerable to out-of-bounds read as it allocates uninitialized Buffers when number is passed in input stream on Node.js 4.x and below.",
+      "recommendation": "No fix is currently available for this vulnerability. It is our recommendation to not install or use this module if user input is being passed in to `stringstream`.\n",
+      "references": "- [HackerOne Report](https://hackerone.com/reports/321670)\n- https://github.com/mhart/StringStream/blob/v0.0.5/stringstream.js#L32",
+      "access": "public",
+      "severity": "moderate",
+      "cwe": "CWE-125",
+      "metadata": {
+        "module_type": "",
+        "exploitability": 2,
+        "affected_components": ""
+      },
+      "url": "https://npmjs.com/advisories/664"
+    },
+    "720": {
+      "findings": [
+        {
+          "version": "3.1.2",
+          "paths": [
+            "@stoplight/prism-cli>@stoplight/prism-http>@stoplight/http-spec>json-schema-generator>request>hawk>cryptiles",
+            "@stoplight/prism-cli>@stoplight/prism-http-server>@stoplight/prism-http>@stoplight/http-spec>json-schema-generator>request>hawk>cryptiles"
+          ]
+        }
+      ],
+      "id": 720,
+      "created": "2018-11-01T18:32:48.906Z",
+      "updated": "2018-11-02T21:39:11.618Z",
+      "deleted": null,
+      "title": "Insufficient Entropy",
+      "found_by": {
+        "link": "https://www.microsoft.com/en-us/msrc/msvr",
+        "name": "Microsoft Vulnerability Research"
+      },
+      "reported_by": {
+        "link": "https://www.microsoft.com/en-us/msrc/msvr",
+        "name": "Microsoft Vulnerability Research"
+      },
+      "module_name": "cryptiles",
+      "cves": [
+        "CVE-2018-1000620"
+      ],
+      "vulnerable_versions": ">=3.1.0 <3.1.3 || >=4.0.0 <4.1.2",
+      "patched_versions": ">=3.1.3 <4.0.0 || >=4.1.2",
+      "overview": "Versions of `cryptiles` from version 3.1.0 through 3.1.2, and versions 4.0.0 to version 4.1.1 are vulnerable to insufficient entropy.  The `randomDigits` method generates digits that lack a perfect distribution over enough attempts.\n",
+      "recommendation": "Update to version 3.1.3 or 4.1.2 or later.",
+      "references": "- [GitHub Issue](https://github.com/hapijs/cryptiles/issues/34)\n- [security-wg](https://github.com/nodejs/security-wg/blob/master/vuln/npm/476.json)",
+      "access": "public",
+      "severity": "high",
+      "cwe": "CWE-331",
+      "metadata": {
+        "module_type": "",
+        "exploitability": 2,
+        "affected_components": ""
+      },
+      "url": "https://npmjs.com/advisories/720"
+    },
+    "996": {
+      "findings": [
+        {
+          "version": "3.0.1",
+          "paths": [
+            "@stoplight/prism-cli>@stoplight/prism-http>@stoplight/http-spec>json-schema-generator>request>extend",
+            "@stoplight/prism-cli>@stoplight/prism-http-server>@stoplight/prism-http>@stoplight/http-spec>json-schema-generator>request>extend"
+          ]
+        }
+      ],
+      "id": 996,
+      "created": "2019-06-19T00:18:20.635Z",
+      "updated": "2019-07-24T18:05:41.047Z",
+      "deleted": null,
+      "title": "Prototype Pollution",
+      "found_by": {
+        "link": "",
+        "name": "asgerf"
+      },
+      "reported_by": {
+        "link": "",
+        "name": "asgerf"
+      },
+      "module_name": "extend",
+      "cves": [],
+      "vulnerable_versions": "<2.0.2 || >=3.0.0 <3.0.2",
+      "patched_versions": ">=2.0.2 <3.0.0 || >=3.0.2",
+      "overview": "Versions of `extend` prior to 3.0.2 (for 3.x) and 2.0.2 (for 2.x) are vulnerable to Prototype Pollution. The `extend()` function allows attackers to modify the prototype of Object causing the addition or modification of an existing property that will exist on all objects.\n\n",
+      "recommendation": "If you're using `extend` 3.x upgrade to 3.0.2 or later.\nIf you're using `extend` 2.x upgrade to 2.0.2 or later.",
+      "references": "- [HackerOne Report](https://hackerone.com/reports/381185)",
+      "access": "public",
+      "severity": "moderate",
+      "cwe": "CWE-471",
+      "metadata": {
+        "module_type": "",
+        "exploitability": 4,
+        "affected_components": ""
+      },
+      "url": "https://npmjs.com/advisories/996"
+    },
+    "1179": {
+      "findings": [
+        {
+          "version": "0.0.8",
+          "paths": [
+            "@stoplight/prism-cli>@stoplight/prism-http>@stoplight/http-spec>json-schema-generator>mkdirp>minimist",
+            "@stoplight/prism-cli>@stoplight/prism-http-server>@stoplight/prism-http>@stoplight/http-spec>json-schema-generator>mkdirp>minimist",
+            "@stoplight/prism-cli>@stoplight/prism-http>@stoplight/http-spec>json-schema-generator>optimist>minimist",
+            "@stoplight/prism-cli>@stoplight/prism-http-server>@stoplight/prism-http>@stoplight/http-spec>json-schema-generator>optimist>minimist"
+          ]
+        }
+      ],
+      "id": 1179,
+      "created": "2019-09-23T15:01:43.049Z",
+      "updated": "2020-03-18T19:41:45.921Z",
+      "deleted": null,
+      "title": "Prototype Pollution",
+      "found_by": {
+        "link": "https://www.checkmarx.com/resources/blog/",
+        "name": "Checkmarx Research Team",
+        "email": ""
+      },
+      "reported_by": {
+        "link": "https://www.checkmarx.com/resources/blog/",
+        "name": "Checkmarx Research Team",
+        "email": ""
+      },
+      "module_name": "minimist",
+      "cves": [],
+      "vulnerable_versions": "<0.2.1 || >=1.0.0 <1.2.3",
+      "patched_versions": ">=0.2.1 <1.0.0 || >=1.2.3",
+      "overview": "Affected versions of `minimist` are vulnerable to prototype pollution. Arguments are not properly sanitized, allowing an attacker to modify the prototype of `Object`, causing the addition or modification of an existing property that will exist on all objects.  \nParsing the argument `--__proto__.y=Polluted` adds a `y` property with value `Polluted` to all objects. The argument `--__proto__=Polluted` raises and uncaught error and crashes the application.  \nThis is exploitable if attackers have control over the arguments being passed to `minimist`.\n",
+      "recommendation": "Upgrade to versions 0.2.1, 1.2.3 or later.",
+      "references": "- [GitHub commit 1](https://github.com/substack/minimist/commit/4cf1354839cb972e38496d35e12f806eea92c11f#diff-a1e0ee62c91705696ddb71aa30ad4f95)\n- [GitHub commit 2](https://github.com/substack/minimist/commit/63e7ed05aa4b1889ec2f3b196426db4500cbda94)",
+      "access": "public",
+      "severity": "low",
+      "cwe": "CWE-471",
+      "metadata": {
+        "module_type": "",
+        "exploitability": 1,
+        "affected_components": ""
+      },
+      "url": "https://npmjs.com/advisories/1179"
+    },
+    "1464": {
+      "findings": [
+        {
+          "version": "3.1.2",
+          "paths": [
+            "@stoplight/prism-cli>@stoplight/prism-http>@stoplight/http-spec>json-schema-generator>request>hawk>cryptiles",
+            "@stoplight/prism-cli>@stoplight/prism-http-server>@stoplight/prism-http>@stoplight/http-spec>json-schema-generator>request>hawk>cryptiles"
+          ]
+        }
+      ],
+      "id": 1464,
+      "created": "2020-01-23T18:13:40.195Z",
+      "updated": "2020-01-30T20:36:38.722Z",
+      "deleted": null,
+      "title": "Insufficient Entropy",
+      "found_by": {
+        "link": "",
+        "name": "Unknown",
+        "email": ""
+      },
+      "reported_by": {
+        "link": "",
+        "name": "Unknown",
+        "email": ""
+      },
+      "module_name": "cryptiles",
+      "cves": [
+        "CVE-2018-1000620"
+      ],
+      "vulnerable_versions": "<4.1.2",
+      "patched_versions": ">=4.1.2",
+      "overview": "Versions of `cryptiles` prior to 4.1.2 are vulnerable to Insufficient Entropy. The `randomDigits()` method does not provide sufficient entropy and its generates digits that are not evenly distributed.",
+      "recommendation": "Upgrade to version 4.1.2. The package is deprecated and has been moved to `@hapi/cryptiles` and it is strongly recommended to use the maintained package.",
+      "references": "- [GitHub PR](https://github.com/hapijs/cryptiles/issues/34)",
+      "access": "public",
+      "severity": "high",
+      "cwe": "CWE-331",
+      "metadata": {
+        "module_type": "",
+        "exploitability": 4,
+        "affected_components": ""
+      },
+      "url": "https://npmjs.com/advisories/1464"
+    },
+    "1523": {
+      "findings": [
+        {
+          "version": "4.17.15",
+          "paths": [
+            "@stoplight/prism-cli>@stoplight/prism-core>lodash",
+            "@stoplight/prism-cli>@stoplight/prism-http>@stoplight/prism-core>lodash",
+            "@stoplight/prism-cli>@stoplight/prism-http-server>@stoplight/prism-http>@stoplight/prism-core>lodash",
+            "@stoplight/prism-cli>@stoplight/prism-http-server>@stoplight/prism-core>lodash"
+          ]
+        },
+        {
+          "version": "4.17.15",
+          "paths": [
+            "@stoplight/prism-cli>@stoplight/prism-http>lodash",
+            "@stoplight/prism-cli>@stoplight/prism-http-server>@stoplight/prism-http>lodash"
+          ]
+        },
+        {
+          "version": "4.17.15",
+          "paths": [
+            "@stoplight/prism-cli>@stoplight/prism-http-server>lodash"
+          ]
+        },
+        {
+          "version": "4.17.15",
+          "paths": [
+            "@stoplight/prism-cli>lodash"
+          ]
+        }
+      ],
+      "id": 1523,
+      "created": "2020-05-20T01:36:49.357Z",
+      "updated": "2020-07-10T19:23:46.395Z",
+      "deleted": null,
+      "title": "Prototype Pollution",
+      "found_by": {
+        "link": "",
+        "name": "posix",
+        "email": ""
+      },
+      "reported_by": {
+        "link": "",
+        "name": "posix",
+        "email": ""
+      },
+      "module_name": "lodash",
+      "cves": [
+        "CVE-2019-10744"
+      ],
+      "vulnerable_versions": "<4.17.19",
+      "patched_versions": ">=4.17.19",
+      "overview": "Versions of `lodash` prior to 4.17.19 are vulnerable to Prototype Pollution.  The function `zipObjectDeep` allows a malicious user to modify the prototype of `Object` if the property identifiers are user-supplied. Being affected by this issue requires zipping objects based on user-provided property arrays.  \n\nThis vulnerability causes the addition or modification of an existing property that will exist on all objects and may lead to Denial of Service or Code Execution under specific circumstances.",
+      "recommendation": "Upgrade to version 4.17.19 or later.",
+      "references": "- [HackerOne Report](https://hackerone.com/reports/712065)\n- [GitHub Issue](https://github.com/lodash/lodash/issues/4744)",
+      "access": "public",
+      "severity": "low",
+      "cwe": "CWE-471",
+      "metadata": {
+        "module_type": "",
+        "exploitability": 3,
+        "affected_components": ""
+      },
+      "url": "https://npmjs.com/advisories/1523"
+    }
+  },
+  "muted": [],
+  "metadata": {
+    "vulnerabilities": {
+      "info": 0,
+      "low": 12,
+      "moderate": 12,
+      "high": 6,
+      "critical": 0
+    },
+    "dependencies": 273,
+    "devDependencies": 2378,
+    "optionalDependencies": 57,
+    "totalDependencies": 2662
+  },
+  "runId": "9f670626-0c54-4706-96c9-faea0fe27119"
+}


### PR DESCRIPTION
# Resolves #72 

# Description
The "dev" field which used to be in the advisories section of the npm audit JSON output has been removed in newer NPM versions. This change allows that information to be gleaned from the "Actions" information in the npm audit data.